### PR TITLE
Replace uint8 with uint8_t

### DIFF
--- a/WeArtCommon.h
+++ b/WeArtCommon.h
@@ -6,6 +6,7 @@
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 
+#include <cstdint>
 #include <string>
 #include "nlohmann/json.hpp"
 
@@ -80,7 +81,7 @@ NLOHMANN_JSON_SERIALIZE_ENUM(MiddlewareStatus, {
 })
 
 
-enum class TextureType : uint8 {
+enum class TextureType : uint8_t {
 	ClickNormal = 0, ClickSoft = 1, DoubleClick = 2,
 	AluminiumFineMeshSlow = 3, AluminiumFineMeshFast = 4,
 	PlasticMeshSlow = 5, ProfiledAluminiumMeshMedium = 6, ProfiledAluminiumMeshFast = 7,

--- a/WeArtController.h
+++ b/WeArtController.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include "WeArtMessageSerializer.h"
+
+#include <cstdint>
 #include <string>
 
 //! @private
@@ -46,7 +48,7 @@ protected:
 
 	bool isCancellationRequested = false;
 	WeArtMessageSerializer messageSerializer;
-	uint8* messageReceivedBuffer[1024];
+	uint8_t* messageReceivedBuffer[1024];
 	std::string trailingText;
 	bool IsConnected = false;
 	bool IsPaused = false;

--- a/WeArtMessages.cpp
+++ b/WeArtMessages.cpp
@@ -418,7 +418,7 @@ void TrackingMessage::setValues(std::vector<std::string>& values) {
 }
 
 float TrackingMessage::GetClosure(HandSide handSide, ActuationPoint actuationPoint) {
-	uint8 byteValue = 0x00;
+	uint8_t byteValue = 0x00;
 	switch (handSide) {
 	case HandSide::Left:
 		switch (actuationPoint) {

--- a/WeArtMessages.h
+++ b/WeArtMessages.h
@@ -5,6 +5,7 @@
 #include <string>
 #include <vector>
 #include <cassert>
+#include <cstdint>
 #include <map>
 #include "nlohmann/json.hpp"
 
@@ -393,18 +394,18 @@ private:
 	TrackingType _trackingType;
 
 	// Closures
-	uint8 RightThumbClosure;
-	uint8 RightIndexClosure;
-	uint8 RightMiddleClosure;
-	uint8 RightPalmClosure;
-	uint8 LeftThumbClosure;
-	uint8 LeftIndexClosure;
-	uint8 LeftMiddleClosure;
-	uint8 LeftPalmClosure;
+	uint8_t RightThumbClosure;
+	uint8_t RightIndexClosure;
+	uint8_t RightMiddleClosure;
+	uint8_t RightPalmClosure;
+	uint8_t LeftThumbClosure;
+	uint8_t LeftIndexClosure;
+	uint8_t LeftMiddleClosure;
+	uint8_t LeftPalmClosure;
 
 	// Abductions
-	uint8 RightThumbAbduction;
-	uint8 LeftThumbAbduction;
+	uint8_t RightThumbAbduction;
+	uint8_t LeftThumbAbduction;
 };
 
 //! @private


### PR DESCRIPTION
Thanks a lot @FrancescoAbbo for all the nice work on the WEART-SDK-Cpp library! 

With @EhsanRanjbari we are trying to use the library with CMake. A small modification that we found useful and I think it could be useful in general was to use the C++ standard `uint8_t` type (provided by the `cstdint` header) instead of the Visual Studio-specific `uint8` . The modifications required are just the one in this PR, and they should work perfectly fine in Visual Studio.

If for any reason you can't integrate this changes, no problem.


